### PR TITLE
Correct '--rm' argument placement in docker run shell script

### DIFF
--- a/.github/workflows/container-remove-flag.yml
+++ b/.github/workflows/container-remove-flag.yml
@@ -1,0 +1,21 @@
+name: Start Redis server with remove container flag
+
+on: [push, pull_request]
+
+jobs:
+  redis-action:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        redis-version: [5, 6, 7]
+
+    name: Start Redis Server v${{ matrix.redis-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Start Redis Server
+        uses: ./
+        with:
+          redis-version: ${{ matrix.redis-version }}
+          redis-remove-container: true  # false by default

--- a/start-redis.sh
+++ b/start-redis.sh
@@ -7,21 +7,28 @@ REDIS_PASSWORD=$4
 REDIS_CONTAINER_NAME=$5
 REDIS_REMOVE_CONTAINER=$6
 
+# 🛡️ Default version fallback
 if [ -z "$REDIS_VERSION" ]; then
   echo "Missing Redis version in the [redis-version] input. Received value: $REDIS_VERSION"
   echo "Falling back to Redis version [latest]"
   REDIS_VERSION='latest'
 fi
 
-DOCKER_RUN_ARGS="--name $REDIS_CONTAINER_NAME --publish $REDIS_PORT:6379 --detach $REDIS_IMAGE:$REDIS_VERSION"
+# 🛠️ Build docker run args
+DOCKER_RUN_ARGS="--name $REDIS_CONTAINER_NAME --publish $REDIS_PORT:6379 --detach"
 
-if [ "$REDIS_REMOVE_CONTAINER" == "true" ]; then
-  DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS --rm"
+# 🗑️ If remove flag is true, run container with --rm (auto-remove on exit)
+if [ "$REDIS_REMOVE_CONTAINER" = "true" ]; then
+  DOCKER_RUN_ARGS="--rm $DOCKER_RUN_ARGS"
 fi
 
+# 🔐 Add password if provided
 if [ -n "$REDIS_PASSWORD" ]; then
-  DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS redis-server --requirepass $REDIS_PASSWORD"
+  DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS $REDIS_IMAGE:$REDIS_VERSION redis-server --requirepass $REDIS_PASSWORD"
+else
+  DOCKER_RUN_ARGS="$DOCKER_RUN_ARGS $REDIS_IMAGE:$REDIS_VERSION"
 fi
 
+# 🚀 Start Redis
 echo "Starting single-node Redis instance: $DOCKER_RUN_ARGS"
 docker run $DOCKER_RUN_ARGS


### PR DESCRIPTION
This PR fixes [issue #26](https://github.com/supercharge/redis-github-action/issues/26) where the `--rm` flag was incorrectly placed **after** the Docker image argument.

* Corrects the argument order so `--rm` is applied **before** the image.
* Adds a new CI workflow (`container-remove-flag.yml`) to test the `redis-remove-container: true` scenario across Redis versions `5, 6, 7`.

This ensures containers start correctly and are automatically removed when requested.
