### PR TITLE
Prepare 2.0.0 Release

### DIFF
--- a/.github/workflows/container-remove-on-exit-flag.yml
+++ b/.github/workflows/container-remove-on-exit-flag.yml
@@ -1,4 +1,4 @@
-name: Start Redis server with remove container flag
+name: Start Redis server with remove container on exit flag
 
 on: [push, pull_request]
 
@@ -18,4 +18,4 @@ jobs:
         uses: ./
         with:
           redis-version: ${{ matrix.redis-version }}
-          redis-remove-container: true  # false by default
+          redis-remove-container-on-exit: true  # false by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2.0.0](https://github.com/supercharge/redis-github-action/compare/v1.8.1...v2.0.0) - not released
+
+### Breaking Changes
+- we renamed the `redis-remove-container` flag to `redis-remove-container-on-exit`
+  ```yaml
+  # BEFORE
+  steps:
+  - name: Start Redis
+    uses: supercharge/redis-github-action@1.8.1
+    with:
+      redis-version: ${{ matrix.redis-version }}
+      redis-remove-container: true # false by default
+
+  # AFTER
+  steps:
+  - name: Start Redis
+    uses: supercharge/redis-github-action@2.0.0
+    with:
+      redis-version: ${{ matrix.redis-version }}
+      redis-remove-container-on-exit: true # false by default
+  ```
+
+
+
 ## [1.8.1](https://github.com/supercharge/redis-github-action/compare/v1.8.0...v1.8.1) - 2025-11-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Start Redis
-      uses: supercharge/redis-github-action@1.8.1
+      uses: supercharge/redis-github-action@2.0.0
       with:
         redis-version: ${{ matrix.redis-version }}
 
@@ -85,7 +85,7 @@ jobs:
 
     steps:
     - name: Start Redis
-      uses: supercharge/redis-github-action@1.8.1
+      uses: supercharge/redis-github-action@2.0.0
       with:
         redis-image: redis/redis-stack-server
         redis-version: ${{ matrix.redis-version }}
@@ -111,7 +111,7 @@ jobs:
 
     steps:
     - name: Start Redis
-      uses: supercharge/redis-github-action@1.8.1
+      uses: supercharge/redis-github-action@2.0.0
       with:
         redis-version: ${{ matrix.redis-version }}
         redis-port: 12345
@@ -137,7 +137,7 @@ jobs:
 
     steps:
     - name: Start Redis
-      uses: supercharge/redis-github-action@1.8.1
+      uses: supercharge/redis-github-action@2.0.0
       with:
         redis-version: ${{ matrix.redis-version }}
         redis-container-name: redis-auth-token-cache
@@ -163,7 +163,7 @@ jobs:
 
     steps:
     - name: Start Redis
-      uses: supercharge/redis-github-action@1.8.1
+      uses: supercharge/redis-github-action@2.0.0
       with:
         redis-version: ${{ matrix.redis-version }}
         redis-password: 'password'
@@ -189,7 +189,7 @@ jobs:
 
     steps:
     - name: Start Redis
-      uses: supercharge/redis-github-action@1.7.0
+      uses: supercharge/redis-github-action@2.0.0
       with:
         redis-version: ${{ matrix.redis-version }}
         redis-remove-container-on-exit: true # false by default

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,6 @@ inputs:
   redis-remove-container-on-exit:
     description: "Remove container after container exit?"
     required: false
-    type: boolean
     default: "false"
 
 runs:


### PR DESCRIPTION

- rename option from `redis-remove-container` to `redis-remove-container-on-exit`